### PR TITLE
Moving dependabot definition

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,6 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
-name: Dependabot
 version: 2
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values


### PR DESCRIPTION
- Moving Dependabot from .github/workflows to .github